### PR TITLE
miniRelIso 0.2 default + multiIsoFlags

### DIFF
--- a/cmgPostProcessing/cmgPostProcessing.py
+++ b/cmgPostProcessing/cmgPostProcessing.py
@@ -25,7 +25,7 @@ from StopsDilepton.tools.mt2Calculator import mt2Calculator
 mt2Calc = mt2Calculator()  #smth smarter possible?
 from StopsDilepton.tools.helpers import closestOSDLMassToMZ, checkRootFile, writeObjToFile, m3, deltaR, bestDRMatchInCollection
 from StopsDilepton.tools.addJERScaling import addJERScaling
-from StopsDilepton.tools.objectSelection import getMuons, getElectrons, muonSelector, eleSelector, getGoodLeptons, getGoodAndOtherLeptons,  getGoodBJets, getGoodJets, isBJet, jetId, isBJet, getGoodPhotons, getGenPartsAll
+from StopsDilepton.tools.objectSelection import getMuons, getElectrons, muonSelector, eleSelector, getGoodLeptons, getGoodAndOtherLeptons,  getGoodBJets, getGoodJets, isBJet, jetId, isBJet, getGoodPhotons, getGenPartsAll, multiIsoWPInt
 from StopsDilepton.tools.overlapRemovalTTG import getTTGJetsEventType
 from StopsDilepton.tools.getGenBoson import getGenZ, getGenPhoton
 
@@ -527,12 +527,12 @@ if isSingleLep:
     new_variables.extend( ['m3/F', 'm3_ind1/I', 'm3_ind2/I', 'm3_ind3/I'] )
 if isTriLep or isDiLep or isSingleLep:
     new_variables.extend( ['nGoodMuons/I', 'nGoodElectrons/I' ] )
-    new_variables.extend( ['l1_pt/F', 'l1_eta/F', 'l1_phi/F', 'l1_pdgId/I', 'l1_index/I', 'l1_jetPtRelv2/F', 'l1_jetPtRatiov2/F', 'l1_miniRelIso/F', 'l1_dxy/F', 'l1_dz/F' ] )
+    new_variables.extend( ['l1_pt/F', 'l1_eta/F', 'l1_phi/F', 'l1_pdgId/I', 'l1_index/I', 'l1_jetPtRelv2/F', 'l1_jetPtRatiov2/F', 'l1_miniRelIso/F', 'l1_dxy/F', 'l1_dz/F', 'l1_mIsoWP/I' ] )
     # new_variables.extend( ['mt/F', 'mlmZ_mass/F'] )
     new_variables.extend( ['mlmZ_mass/F'] )
     new_variables.extend( ['mt_photonEstimated/F'] )
 if isTriLep or isDiLep:
-    new_variables.extend( ['l2_pt/F', 'l2_eta/F', 'l2_phi/F', 'l2_pdgId/I', 'l2_index/I', 'l2_jetPtRelv2/F', 'l2_jetPtRatiov2/F', 'l2_miniRelIso/F', 'l2_dxy/F', 'l2_dz/F' ] )
+    new_variables.extend( ['l2_pt/F', 'l2_eta/F', 'l2_phi/F', 'l2_pdgId/I', 'l2_index/I', 'l2_jetPtRelv2/F', 'l2_jetPtRatiov2/F', 'l2_miniRelIso/F', 'l2_dxy/F', 'l2_dz/F', 'l2_mIsoWP/I' ] )
     new_variables.extend( ['isEE/I', 'isMuMu/I', 'isEMu/I', 'isOS/I' ] )
     new_variables.extend( ['dl_pt/F', 'dl_eta/F', 'dl_phi/F', 'dl_mass/F'] )
     new_variables.extend( ['dl_mt2ll/F', 'dl_mt2bb/F', 'dl_mt2blbl/F' ] )
@@ -682,12 +682,14 @@ def filler(s):
         leptons_pt10 = getGoodLeptons(r, ptCut=10, mu_selector = mu_selector, ele_selector = ele_selector)
         leptons      = filter(lambda l:l['pt']>20, leptons_pt10)
     else:
-        # default lepton selection
-        leptons_pt10 = getGoodLeptons(r, ptCut=10)
+        # using miniRelIso 0.2 as baseline 
+        mu_selector = muonSelector( iso = 0.2 )
+        ele_selector = eleSelector( iso = 0.2 )
+        leptons_pt10 = getGoodLeptons(r, ptCut=10, mu_selector = mu_selector, ele_selector = ele_selector)
         leptons      = filter(lambda l:l['pt']>20, leptons_pt10)
 
     leptons.sort(key = lambda p:-p['pt'])
-
+    
     s.met_pt  = r.met_pt
     s.met_phi = r.met_phi
 
@@ -776,6 +778,7 @@ def filler(s):
             s.l1_miniRelIso = leptons[0]['miniRelIso']
             s.l1_dxy = leptons[0]['dxy']
             s.l1_dz = leptons[0]['dz']
+            s.l1_mIsoWP = multiIsoWPInt(leptons[0])
 
         # For TTZ studies: find Z boson candidate, and use third lepton to calculate mt
         (s.mlmZ_mass, zl1, zl2) = closestOSDLMassToMZ(leptons_pt10)
@@ -821,6 +824,7 @@ def filler(s):
             s.l2_miniRelIso = leptons[1]['miniRelIso']
             s.l2_dxy = leptons[1]['dxy']
             s.l2_dz = leptons[1]['dz']
+            s.l2_mIsoWP = multiIsoWPInt(leptons[1])
             
 
             l_pdgs = [abs(leptons[0]['pdgId']), abs(leptons[1]['pdgId'])]

--- a/tools/python/objectSelection.py
+++ b/tools/python/objectSelection.py
@@ -80,6 +80,22 @@ def multiIsoSelector(WP):
             and (l["jetPtRatiov2"]>multiIsoWP[WP]['ptRatiov2'] or l['jetPtRelv2']>multiIsoWP[WP]['ptRelv2'] )
     return func
 
+
+__VT = multiIsoSelector('VT')
+__T = multiIsoSelector('T')
+__M = multiIsoSelector('M')
+__L = multiIsoSelector('L')
+__VL = multiIsoSelector('VL')
+def multiIsoWPInt( l ):
+    #Static functions so we don't construct them for each lepton
+
+    if   __VT( l ): return 5
+    elif __T ( l ): return 4
+    elif __M ( l ): return 3
+    elif __L ( l ): return 2
+    elif __VL( l ): return 1
+    return 0
+
 def miniIsoSelector( miniRelIso ):
     assert isinstance(miniRelIso, numbers.Number), "Don't know what to do with miniRelIso %r"%miniRelIso
     def func(l):


### PR DESCRIPTION
Changed the default to multiIso 0.2 and added l1_mIsoWP l2_mIsoWP that run from 0 (none), 1(VL) to 5(VT)

I've left the default_muon_selector and default_ele_selector @ multiIso VT
